### PR TITLE
Better error handling

### DIFF
--- a/src/extension/src/main/java/org/neo4j/nlp/ext/PatternRecognitionResource.java
+++ b/src/extension/src/main/java/org/neo4j/nlp/ext/PatternRecognitionResource.java
@@ -52,7 +52,7 @@ public class PatternRecognitionResource {
         try {
             input = objectMapper.readValue(body, HashMap.class);
         } catch (Exception e) {
-            return Response.status(200).entity("{\"error\":\"" + Arrays.toString(e.getStackTrace()) + "\"}").build();
+            return Response.status(200).entity("{\"error\":\"" + Arrays.toString(e.getStackTrace()) + "\", \"message\":\"" + e.getMessage() + "\"}").build();
         }
         LabeledText labeledText = new LabeledText();
         ArrayList labels = (ArrayList) input.get("label");


### PR DESCRIPTION
I keep getting an error here and the stacktrace just shows org.codehaus.jackson.JsonParser._constructError . Would be better to send the error message also.
I am unable to build graphify with dependencies locally but guess that is because of my environment.
Can you add this and generate a new jar file in the bin folder.